### PR TITLE
fix(DataManager): handle duplicate keychain entries by adding secureU…

### DIFF
--- a/Sources/DataManager/DataManager.swift
+++ b/Sources/DataManager/DataManager.swift
@@ -129,12 +129,29 @@ public class DataManager {
             try keychain.save(key: file, value: value)
             return true
         } catch {
-            if let error = error as? KeyManager.KeyError { lastError = error }
+            if let error = error as? KeyManager.KeyError {
+                if case .duplicateEntry = error {
+                    return secureUpdate(file, value: value)
+                }
+                lastError = error
+            }
             return false
         }
     }
     
     private func secureExist(_ file: String) -> Bool { keychain.exists(key: file) }
+    
+    private func secureUpdate<T: Codable>(_ file: String, value: T) -> Bool {
+        do {
+            try keychain.update(key: file, value: value)
+            return true
+        } catch {
+            if let error = error as? KeyManager.KeyError {
+                lastError = error
+            }
+            return false
+        }
+    }
     
     private func secureRetrive<T: Codable>(_ file: String) -> T? {
         do {


### PR DESCRIPTION
…pdate

When a duplicate entry error occurs during secureSave, call the new secureUpdate method instead of returning false. This ensures data persistence when overwriting existing entries.